### PR TITLE
build: improve installer options to persist application in a machine

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,7 +81,14 @@ jlink {
         appVersion = version.toString()
         if(System.getProperty("os.name").lowercase(Locale.getDefault()).contains("windows")) {
           imageOptions.addAll(listOf("--icon", "${projectDir}/src/main/resources/assets/icon.ico"))
-          installerOptions.addAll(listOf("--win-per-user-install","--win-dir-chooser", "--win-menu", "--win-shortcut", "--win-shortcut-prompt"))
+          installerOptions.addAll(listOf(
+              "--win-per-user-install",
+              "--win-menu-group", "MinecraftTimeMachine",
+              "--win-menu",
+              "--win-upgrade-uuid", "61c4988a-2efe-406c-980c-15ae268d7627",
+              "--vendor", "Secret Society Braid (@hizumiaoba)",
+              "--win-shortcut",
+              "--win-shortcut-prompt"))
         }
     }
 }


### PR DESCRIPTION
it will need to uninstall previous version before update to this version due to mismatching of `upgradeCode` UUID.

This update:

- Adds `upgradeCode` UUID to tell WiX installer uses to install software.
- Adds `vandor` meta information.
- Adds new start menu group called `MinecraftTimeMachine`